### PR TITLE
Closes #14 Added growth to outdated platforms

### DIFF
--- a/lib/interfaces/dlive/user.ts
+++ b/lib/interfaces/dlive/user.ts
@@ -6,13 +6,14 @@ import {
   UserGeneral,
   Id,
   SmallBranding,
+  GrowthNumbers,
 } from '../matrix.shared';
 import { DLiveGeneral, DLiveRanks, DLiveTotal } from './shared';
 
 export type DLiveUserGeneral = DLiveGeneral & UserGeneral<SmallBranding>;
 
 export interface DLiveUser
-  extends Data<Id, DLiveUserGeneral, Statistics<DLiveTotal>, DLiveRanks> {
+  extends Data<Id, DLiveUserGeneral, DLiveStatistics, DLiveRanks> {
   misc: DLiveMisc;
   daily: DLiveDaily[];
 }
@@ -30,4 +31,13 @@ export interface DLiveRecent {
   name: string | null;
   cover: string | null;
   background: string | null;
+}
+
+export interface DLiveGrowth {
+  followers: GrowthNumbers;
+  videos: GrowthNumbers;
+}
+
+export interface DLiveStatistics extends Statistics<DLiveTotal> {
+  growth: DLiveGrowth;
 }

--- a/lib/interfaces/facebook/user.ts
+++ b/lib/interfaces/facebook/user.ts
@@ -5,6 +5,7 @@ import {
   Statistics,
   UserGeneral,
   ExtendedId,
+  GrowthNumbers,
 } from '../matrix.shared';
 import { FacebookRanks, FacebookTotal } from './shared';
 
@@ -14,7 +15,7 @@ export interface FacebookUser
   extends Data<
     ExtendedId,
     FacebookUserGeneral,
-    Statistics<FacebookTotal>,
+    FacebookStatistics,
     FacebookRanks
   > {
   misc: Misc;
@@ -24,4 +25,13 @@ export interface FacebookUser
 export interface FacebookDaily extends Daily {
   likes: number;
   talking_about: number;
+}
+
+export interface FacebookGrowth {
+  likes: GrowthNumbers;
+  talking_about: GrowthNumbers;
+}
+
+export interface FacebookStatistics extends Statistics<FacebookTotal> {
+  growth: FacebookGrowth;
 }

--- a/lib/interfaces/instagram/user.ts
+++ b/lib/interfaces/instagram/user.ts
@@ -2,6 +2,7 @@ import {
   Daily,
   Data,
   ExtendedId,
+  GrowthNumbers,
   Misc,
   Statistics,
   UserGeneral,
@@ -20,7 +21,7 @@ export interface InstagramUser
   extends Data<
     ExtendedId,
     InstagramUserGeneral,
-    Statistics<InstagramTotal>,
+    InstagramStatistics,
     InstagramRanks
   > {
   misc: Misc;
@@ -33,4 +34,13 @@ export interface InstagramDaily extends Daily {
   media: number;
   avg_likes: number;
   avg_comments: number;
+}
+
+export interface InstagramGrowth {
+  followers: GrowthNumbers;
+  media: GrowthNumbers;
+}
+
+export interface InstagramStatistics extends Statistics<InstagramTotal> {
+  growth: InstagramGrowth;
 }

--- a/lib/interfaces/matrix.shared.ts
+++ b/lib/interfaces/matrix.shared.ts
@@ -43,3 +43,15 @@ export interface UserGeneral<T = Branding> {
 export interface Statistics<Total> {
   total: Total;
 }
+
+export interface GrowthNumbers {
+  '1'?: number;
+  '3'?: number;
+  '7'?: number;
+  '14'?: number;
+  '30'?: number;
+  '60'?: number;
+  '90'?: number;
+  '180'?: number;
+  '365'?: number;
+}

--- a/lib/interfaces/storyfire/user.ts
+++ b/lib/interfaces/storyfire/user.ts
@@ -6,6 +6,7 @@ import {
   UserGeneral,
   Id,
   SmallBranding,
+  GrowthNumbers,
 } from '../matrix.shared';
 import { StoryFireGeneral, StoryFireRanks, StoryFireTotal } from './shared';
 
@@ -13,14 +14,19 @@ export type StoryFireUserGeneral = StoryFireGeneral &
   UserGeneral<SmallBranding>;
 
 export interface StoryFireUser
-  extends Data<
-    Id,
-    StoryFireUserGeneral,
-    Statistics<StoryFireTotal>,
-    StoryFireRanks
-  > {
+  extends Data<Id, StoryFireUserGeneral, StoryFireStatistics, StoryFireRanks> {
   misc: Misc;
   daily: StoryFireDaily[];
 }
 
 export type StoryFireDaily = Daily & StoryFireTotal;
+
+export interface StoryFireGrowth {
+  followers: GrowthNumbers;
+  views: GrowthNumbers;
+  videos: GrowthNumbers;
+}
+
+export interface StoryFireStatistics extends Statistics<StoryFireTotal> {
+  growth: StoryFireGrowth;
+}

--- a/lib/interfaces/trovo/user.ts
+++ b/lib/interfaces/trovo/user.ts
@@ -6,18 +6,14 @@ import {
   UserGeneral,
   SmallBranding,
   ExtendedId,
+  GrowthNumbers,
 } from '../matrix.shared';
 import { TrovoGeneral, TrovoRanks, TrovoTotal } from './shared';
 
 export type TrovoUserGeneral = TrovoGeneral & UserGeneral<SmallBranding>;
 
 export interface TrovoUser
-  extends Data<
-    ExtendedId,
-    TrovoUserGeneral,
-    Statistics<TrovoTotal>,
-    TrovoRanks
-  > {
+  extends Data<ExtendedId, TrovoUserGeneral, TrovoStatistics, TrovoRanks> {
   misc: TrovoMisc;
   daily: TrovoDaily[];
 }
@@ -32,4 +28,12 @@ export interface TrovoMisc extends Misc {
 export interface TrovoRecent {
   game: string;
   status: string;
+}
+
+export interface TrovoGrowth {
+  followers: GrowthNumbers;
+}
+
+export interface TrovoStatistics extends Statistics<TrovoTotal> {
+  growth: TrovoGrowth;
 }

--- a/lib/interfaces/twitch/user.ts
+++ b/lib/interfaces/twitch/user.ts
@@ -6,18 +6,14 @@ import {
   Branding,
   UserGeneral,
   ExtendedId,
+  GrowthNumbers,
 } from '../matrix.shared';
 import { TwitchGeneral, TwitchRanks, TwitchTotal } from './shared';
 
 export type TwitchUserGeneral = TwitchGeneral & UserGeneral<Branding>;
 
 export interface TwitchUser
-  extends Data<
-    ExtendedId,
-    TwitchUserGeneral,
-    Statistics<TwitchTotal>,
-    TwitchRanks
-  > {
+  extends Data<ExtendedId, TwitchUserGeneral, TwitchStatistics, TwitchRanks> {
   misc: TwitchMisc;
   daily: TwitchDaily[];
 }
@@ -32,4 +28,12 @@ export interface TwitchMisc extends Misc {
 export interface TwitchRecent {
   game: string;
   status: string;
+}
+
+export interface TwitchGrowth {
+  followers: GrowthNumbers;
+}
+
+export interface TwitchStatistics extends Statistics<TwitchTotal> {
+  growth: TwitchGrowth;
 }

--- a/lib/interfaces/twitter/user.ts
+++ b/lib/interfaces/twitter/user.ts
@@ -6,6 +6,7 @@ import {
   Branding,
   Statistics,
   UserGeneral,
+  GrowthNumbers,
 } from '../matrix.shared';
 import { TwitterGeneral, TwitterRanks, TwitterTotal } from './shared';
 
@@ -15,7 +16,7 @@ export interface TwitterUser
   extends Data<
     ExtendedId,
     TwitterUserGeneral,
-    Statistics<TwitterTotal>,
+    TwitterStatistics,
     TwitterRanks
   > {
   misc: TwitterMisc;
@@ -35,4 +36,13 @@ export interface TwitterDaily extends Daily {
 
 export interface TwitterMisc extends Misc {
   twitter_verified: boolean;
+}
+
+export interface TwitterGrowth {
+  followers: GrowthNumbers;
+  tweets: GrowthNumbers;
+}
+
+export interface TwitterStatistics extends Statistics<TwitterTotal> {
+  growth: TwitterGrowth;
 }

--- a/lib/interfaces/youtube/user.ts
+++ b/lib/interfaces/youtube/user.ts
@@ -5,6 +5,7 @@ import {
   Statistics,
   Branding,
   UserGeneral,
+  GrowthNumbers,
 } from '../matrix.shared';
 import {
   YouTubeGeneral,
@@ -45,21 +46,9 @@ export interface YouTubeMisc extends Misc {
   tags: string[];
 }
 
-export interface YouTubeGrowthNumbers {
-  '1'?: number;
-  '3'?: number;
-  '7'?: number;
-  '14'?: number;
-  '30'?: number;
-  '60'?: number;
-  '90'?: number;
-  '180'?: number;
-  '365'?: number;
-}
-
 export interface YouTubeGrowth {
-  subs: YouTubeGrowthNumbers;
-  vidviews: YouTubeGrowthNumbers;
+  subs: GrowthNumbers;
+  vidviews: GrowthNumbers;
 }
 
 export interface YouTubeStatistics extends Statistics<YouTubeTotal> {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socialblade",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Library for Social Blade's Official API in JavaScript (TypeScript)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/dlive.ts
+++ b/tests/dlive.ts
@@ -31,5 +31,14 @@ describe('DLive Client API', function () {
     it('History should contain 30 days', async function () {
       expect((this.sbStats as DLiveUser).daily.length).to.be.eq(30);
     });
+
+    it('Growth should be a number', async function () {
+      expect(
+        (this.sbStats as DLiveUser).statistics.growth.followers[30],
+      ).to.be.a('number');
+      expect((this.sbStats as DLiveUser).statistics.growth.videos[30]).to.be.a(
+        'number',
+      );
+    });
   });
 });

--- a/tests/facebook.ts
+++ b/tests/facebook.ts
@@ -31,6 +31,15 @@ describe('Facebook Client API', function () {
     it('History should contain 30 days', async function () {
       expect((this.sbStats as FacebookUser).daily.length).to.be.eq(30);
     });
+
+    it('Growth should be a number', async function () {
+      expect(
+        (this.sbStats as FacebookUser).statistics.growth.likes[30],
+      ).to.be.a('number');
+      expect(
+        (this.sbStats as FacebookUser).statistics.growth.talking_about[30],
+      ).to.be.a('number');
+    });
   });
 
   describe('Facebook Top Lists', function () {

--- a/tests/instagram.ts
+++ b/tests/instagram.ts
@@ -35,6 +35,15 @@ describe('Instagram Client API', function () {
     it('History should contain 30 days', async function () {
       expect((this.sbStats as InstagramUser).daily.length).to.be.eq(30);
     });
+
+    it('Growth should be a number', async function () {
+      expect(
+        (this.sbStats as InstagramUser).statistics.growth.followers[30],
+      ).to.be.a('number');
+      expect(
+        (this.sbStats as InstagramUser).statistics.growth.media[30],
+      ).to.be.a('number');
+    });
   });
 
   describe('Instagram Vault', function () {

--- a/tests/storyfire.ts
+++ b/tests/storyfire.ts
@@ -31,5 +31,17 @@ describe('StoryFire Client API', function () {
     it('History should contain 30 days', async function () {
       expect((this.sbStats as StoryFireUser).daily.length).to.be.eq(30);
     });
+
+    it('Growth should be a number', async function () {
+      expect(
+        (this.sbStats as StoryFireUser).statistics.growth.followers[30],
+      ).to.be.a('number');
+      expect(
+        (this.sbStats as StoryFireUser).statistics.growth.views[30],
+      ).to.be.a('number');
+      expect(
+        (this.sbStats as StoryFireUser).statistics.growth.videos[30],
+      ).to.be.a('number');
+    });
   });
 });

--- a/tests/trovo.ts
+++ b/tests/trovo.ts
@@ -31,5 +31,11 @@ describe('Trovo Client API', function () {
     it('History should contain more than 7 days', async function () {
       expect((this.sbStats as TrovoUser).daily.length).to.be.greaterThan(7);
     });
+
+    it('Growth should be a number', async function () {
+      expect(
+        (this.sbStats as TrovoUser).statistics.growth.followers[30],
+      ).to.be.a('number');
+    });
   });
 });

--- a/tests/twitch.ts
+++ b/tests/twitch.ts
@@ -31,6 +31,12 @@ describe('Twitch Client API', function () {
     it('History should contain 30 days', async function () {
       expect((this.sbStats as TwitchUser).daily.length).to.be.eq(30);
     });
+
+    it('Growth should be a number', async function () {
+      expect(
+        (this.sbStats as TwitchUser).statistics.growth.followers[30],
+      ).to.be.a('number');
+    });
   });
 
   describe('Twitch Top Lists', function () {

--- a/tests/twitter.ts
+++ b/tests/twitter.ts
@@ -28,6 +28,15 @@ describe('Twitter Client API', function () {
       );
     });
 
+    it('Growth should be a number', async function () {
+      expect(
+        (this.sbStats as TwitterUser).statistics.growth.followers[30],
+      ).to.be.a('number');
+      expect(
+        (this.sbStats as TwitterUser).statistics.growth.tweets[30],
+      ).to.be.a('number');
+    });
+
     it('History should contain 30 days', async function () {
       expect((this.sbStats as TwitterUser).daily.length).to.be.eq(30);
     });


### PR DESCRIPTION
- Added to DLive, Facebook, Instagram, Storyfire, Trovo, Twitch, and Twitter.
- Removed YouTubeGrowthNumbers and Changed to GrowthNumbers in matrix shared.